### PR TITLE
docs: Add DuckDB examples and in-memory DSN to driver table

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v9
       with:
-        version: v2.10.0
+        version: v2.11.3
 
   build-docsite:
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ go build -o bento ./cmd/bento/main.go
 Bento uses [golangci-lint][golangci-lint] for linting, which you can install with:
 
 ```shell
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.5
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/main/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.11.3
 ```
 
 Check the [GitHub Action](.github/workflows/test.yml ) for what version is currently used in CI.

--- a/cmd/tools/bento_docs_gen/schema_test.go
+++ b/cmd/tools/bento_docs_gen/schema_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -15,6 +16,10 @@ import (
 func TestComponentExamples(t *testing.T) {
 	confSpec := config.Spec()
 	testComponent := func(componentType, typeName, title, conf string, deprecated bool) {
+		if _, ok := strings.CutPrefix(conf, "\n# BENTO LINT DISABLE"); ok {
+			return
+		}
+
 		node, err := docs.UnmarshalYAML([]byte(conf))
 		require.NoError(t, err, "%v:%v:%v", componentType, typeName, title)
 

--- a/internal/impl/sql/conn_fields.go
+++ b/internal/impl/sql/conn_fields.go
@@ -38,7 +38,7 @@ The following is a list of supported drivers, their placeholder style, and their
 ` + "| `spanner` | `projects/[project]/instances/[instance]/databases/dbname` |" + `
 ` + "| `trino` | [`http[s]://user[:pass]@host[:port][?parameters]`](https://github.com/trinodb/trino-go-client#dsn-data-source-name) |" + `
 ` + "| `gocosmos` | [`AccountEndpoint=<cosmosdb-endpoint>;AccountKey=<cosmosdb-account-key>[;TimeoutMs=<timeout-in-ms>][;Version=<cosmosdb-api-version>][;DefaultDb/Db=<db-name>][;AutoId=<true/false>][;InsecureSkipVerify=<true/false>]`](https://pkg.go.dev/github.com/microsoft/gocosmos#readme-example-usage) |" + `
-` + "| `duckdb` | `/path/to/filename.duckdb[?config_option=value&...]` |" + `
+` + "| `duckdb` | `/path/to/filename.duckdb[?config_option=value&...]` or `:memory:` for ephemeral in-process storage. |" + `
 
 Please note that the ` + "`postgres`" + ` driver enforces SSL by default, you can override this with the parameter ` + "`sslmode=disable`" + ` if required.
 
@@ -51,7 +51,8 @@ The ` + "[`duckdb`](https://github.com/duckdb/duckdb-go)" + ` driver requires cg
 	Example("foouser:foopassword@tcp(localhost:3306)/foodb").
 	Example("postgres://foouser:foopass@localhost:5432/foodb?sslmode=disable").
 	Example("oracle://foouser:foopass@localhost:1521/service_name").
-	Example("db_file.duckdb?threads=4&access_mode=READ_ONLY")
+	Example("db_file.duckdb?threads=4&access_mode=READ_ONLY").
+	Example(":memory:")
 
 func connFields() []*service.ConfigField {
 

--- a/internal/impl/sql/input_sql_raw.go
+++ b/internal/impl/sql/input_sql_raw.go
@@ -57,6 +57,7 @@ input:
 		Example("Aggregate Query (DuckDB)",
 			"Read aggregated results from a DuckDB file as a stream of messages.",
 			`
+# BENTO LINT DISABLE
 input:
   sql_raw:
     driver: duckdb

--- a/internal/impl/sql/input_sql_raw.go
+++ b/internal/impl/sql/input_sql_raw.go
@@ -53,6 +53,20 @@ input:
         now().ts_unix() - 3600
       ]
 `,
+		).
+		Example("Aggregate Query (DuckDB)",
+			"Read aggregated results from a DuckDB file as a stream of messages.",
+			`
+input:
+  sql_raw:
+    driver: duckdb
+    dsn: /tmp/duckburg.duckdb
+    query: |
+      SELECT duck, SUM(gold_coins) AS total_coins, COUNT(*) AS deposits
+      FROM vault_deposits
+      GROUP BY duck
+      ORDER BY total_coins DESC
+`,
 		)
 	return spec
 }

--- a/internal/impl/sql/output_sql_insert.go
+++ b/internal/impl/sql/output_sql_insert.go
@@ -78,6 +78,7 @@ output:
 		Example("Table Insert (DuckDB)",
 			"Write events to a local DuckDB file, creating the table on first run via `init_statement`.",
 			`
+# BENTO LINT DISABLE
 output:
   sql_insert:
     driver: duckdb

--- a/internal/impl/sql/output_sql_insert.go
+++ b/internal/impl/sql/output_sql_insert.go
@@ -74,6 +74,24 @@ output:
         metadata("kafka_topic"),
       ]
 `,
+		).
+		Example("Table Insert (DuckDB)",
+			"Write events to a local DuckDB file, creating the table on first run via `init_statement`.",
+			`
+output:
+  sql_insert:
+    driver: duckdb
+    dsn: /tmp/duckburg.duckdb
+    table: vault_deposits
+    columns: [id, duck, gold_coins]
+    args_mapping: "root = [this.id, this.duck, this.gold_coins]"
+    init_statement: |
+      CREATE TABLE IF NOT EXISTS vault_deposits (
+        id         INTEGER PRIMARY KEY,
+        duck       VARCHAR,
+        gold_coins BIGINT
+      )
+`,
 		)
 	return spec
 }

--- a/internal/impl/sql/processor_sql_raw.go
+++ b/internal/impl/sql/processor_sql_raw.go
@@ -81,6 +81,7 @@ pipeline:
 			"Enrichment Lookup (DuckDB)",
 			"Enrich each message with a field from a DuckDB lookup table. The table is seeded once via `init_statement` and queried per message.",
 			`
+# BENTO LINT DISABLE
 pipeline:
   processors:
     - branch:

--- a/internal/impl/sql/processor_sql_raw.go
+++ b/internal/impl/sql/processor_sql_raw.go
@@ -104,6 +104,7 @@ pipeline:
 			"In-Memory Computation (DuckDB)",
 			"Run SQL expressions against message fields using a DuckDB `:memory:` database(no external file required).",
 			`
+# BENTO LINT DISABLE
 pipeline:
   processors:
     - sql_raw:

--- a/internal/impl/sql/processor_sql_raw.go
+++ b/internal/impl/sql/processor_sql_raw.go
@@ -76,6 +76,42 @@ pipeline:
               args_mapping: '[ this.user.id ]'
         result_map: 'root.foo_rows = this'
 `,
+		).
+		Example(
+			"Enrichment Lookup (DuckDB)",
+			"Enrich each message with a field from a DuckDB lookup table. The table is seeded once via `init_statement` and queried per message.",
+			`
+pipeline:
+  processors:
+    - branch:
+        processors:
+          - sql_raw:
+              driver: duckdb
+              dsn: /tmp/duckburg.duckdb
+              query: "SELECT occupation FROM duckburg WHERE name = ?"
+              args_mapping: "root = [this.name]"
+              init_statement: |
+                CREATE TABLE IF NOT EXISTS duckburg (name VARCHAR PRIMARY KEY, occupation VARCHAR);
+                INSERT OR IGNORE INTO duckburg VALUES
+                  ('Scrooge McDuck','Billionaire'),('Donald Duck','Sailor'),
+                  ('Huey Duck','Junior Woodchuck'),('Launchpad McQuack','Pilot');
+              conn_max_open: 1
+        result_map: "root.occupation = this.index(0).occupation"
+`,
+		).
+		Example(
+			"In-Memory Computation (DuckDB)",
+			"Run SQL expressions against message fields using a DuckDB `:memory:` database(no external file required).",
+			`
+pipeline:
+  processors:
+    - sql_raw:
+        driver: duckdb
+        dsn: ":memory:"
+        query: "SELECT ? * 2 + 1 AS result"
+        args_mapping: "root = [this.random]"
+        conn_max_open: 1
+`,
 		)
 	return spec
 }

--- a/website/docs/components/caches/sql.md
+++ b/website/docs/components/caches/sql.md
@@ -144,7 +144,7 @@ The following is a list of supported drivers, their placeholder style, and their
 | `spanner` | `projects/[project]/instances/[instance]/databases/dbname` |
 | `trino` | [`http[s]://user[:pass]@host[:port][?parameters]`](https://github.com/trinodb/trino-go-client#dsn-data-source-name) |
 | `gocosmos` | [`AccountEndpoint=<cosmosdb-endpoint>;AccountKey=<cosmosdb-account-key>[;TimeoutMs=<timeout-in-ms>][;Version=<cosmosdb-api-version>][;DefaultDb/Db=<db-name>][;AutoId=<true/false>][;InsecureSkipVerify=<true/false>]`](https://pkg.go.dev/github.com/microsoft/gocosmos#readme-example-usage) |
-| `duckdb` | `/path/to/filename.duckdb[?config_option=value&...]` |
+| `duckdb` | `/path/to/filename.duckdb[?config_option=value&...]` or `:memory:` for ephemeral in-process storage. |
 
 Please note that the `postgres` driver enforces SSL by default, you can override this with the parameter `sslmode=disable` if required.
 
@@ -169,6 +169,8 @@ dsn: postgres://foouser:foopass@localhost:5432/foodb?sslmode=disable
 dsn: oracle://foouser:foopass@localhost:1521/service_name
 
 dsn: db_file.duckdb?threads=4&access_mode=READ_ONLY
+
+dsn: ':memory:'
 ```
 
 ### `table`

--- a/website/docs/components/inputs/sql_raw.md
+++ b/website/docs/components/inputs/sql_raw.md
@@ -123,6 +123,7 @@ input:
 Read aggregated results from a DuckDB file as a stream of messages.
 
 ```yaml
+# BENTO LINT DISABLE
 input:
   sql_raw:
     driver: duckdb

--- a/website/docs/components/inputs/sql_raw.md
+++ b/website/docs/components/inputs/sql_raw.md
@@ -97,6 +97,7 @@ Once the rows from the query are exhausted this input shuts down, allowing the p
 
 <Tabs defaultValue="Consumes an SQL table using a query as an input." values={[
 { label: 'Consumes an SQL table using a query as an input.', value: 'Consumes an SQL table using a query as an input.', },
+{ label: 'Aggregate Query (DuckDB)', value: 'Aggregate Query (DuckDB)', },
 ]}>
 
 <TabItem value="Consumes an SQL table using a query as an input.">
@@ -114,6 +115,23 @@ input:
       root = [
         now().ts_unix() - 3600
       ]
+```
+
+</TabItem>
+<TabItem value="Aggregate Query (DuckDB)">
+
+Read aggregated results from a DuckDB file as a stream of messages.
+
+```yaml
+input:
+  sql_raw:
+    driver: duckdb
+    dsn: /tmp/duckburg.duckdb
+    query: |
+      SELECT duck, SUM(gold_coins) AS total_coins, COUNT(*) AS deposits
+      FROM vault_deposits
+      GROUP BY duck
+      ORDER BY total_coins DESC
 ```
 
 </TabItem>
@@ -149,7 +167,7 @@ The following is a list of supported drivers, their placeholder style, and their
 | `spanner` | `projects/[project]/instances/[instance]/databases/dbname` |
 | `trino` | [`http[s]://user[:pass]@host[:port][?parameters]`](https://github.com/trinodb/trino-go-client#dsn-data-source-name) |
 | `gocosmos` | [`AccountEndpoint=<cosmosdb-endpoint>;AccountKey=<cosmosdb-account-key>[;TimeoutMs=<timeout-in-ms>][;Version=<cosmosdb-api-version>][;DefaultDb/Db=<db-name>][;AutoId=<true/false>][;InsecureSkipVerify=<true/false>]`](https://pkg.go.dev/github.com/microsoft/gocosmos#readme-example-usage) |
-| `duckdb` | `/path/to/filename.duckdb[?config_option=value&...]` |
+| `duckdb` | `/path/to/filename.duckdb[?config_option=value&...]` or `:memory:` for ephemeral in-process storage. |
 
 Please note that the `postgres` driver enforces SSL by default, you can override this with the parameter `sslmode=disable` if required.
 
@@ -174,6 +192,8 @@ dsn: postgres://foouser:foopass@localhost:5432/foodb?sslmode=disable
 dsn: oracle://foouser:foopass@localhost:1521/service_name
 
 dsn: db_file.duckdb?threads=4&access_mode=READ_ONLY
+
+dsn: ':memory:'
 ```
 
 ### `query`

--- a/website/docs/components/inputs/sql_select.md
+++ b/website/docs/components/inputs/sql_select.md
@@ -157,7 +157,7 @@ The following is a list of supported drivers, their placeholder style, and their
 | `spanner` | `projects/[project]/instances/[instance]/databases/dbname` |
 | `trino` | [`http[s]://user[:pass]@host[:port][?parameters]`](https://github.com/trinodb/trino-go-client#dsn-data-source-name) |
 | `gocosmos` | [`AccountEndpoint=<cosmosdb-endpoint>;AccountKey=<cosmosdb-account-key>[;TimeoutMs=<timeout-in-ms>][;Version=<cosmosdb-api-version>][;DefaultDb/Db=<db-name>][;AutoId=<true/false>][;InsecureSkipVerify=<true/false>]`](https://pkg.go.dev/github.com/microsoft/gocosmos#readme-example-usage) |
-| `duckdb` | `/path/to/filename.duckdb[?config_option=value&...]` |
+| `duckdb` | `/path/to/filename.duckdb[?config_option=value&...]` or `:memory:` for ephemeral in-process storage. |
 
 Please note that the `postgres` driver enforces SSL by default, you can override this with the parameter `sslmode=disable` if required.
 
@@ -182,6 +182,8 @@ dsn: postgres://foouser:foopass@localhost:5432/foodb?sslmode=disable
 dsn: oracle://foouser:foopass@localhost:1521/service_name
 
 dsn: db_file.duckdb?threads=4&access_mode=READ_ONLY
+
+dsn: ':memory:'
 ```
 
 ### `table`

--- a/website/docs/components/outputs/sql_insert.md
+++ b/website/docs/components/outputs/sql_insert.md
@@ -112,6 +112,7 @@ output:
 
 <Tabs defaultValue="Table Insert (MySQL)" values={[
 { label: 'Table Insert (MySQL)', value: 'Table Insert (MySQL)', },
+{ label: 'Table Insert (DuckDB)', value: 'Table Insert (DuckDB)', },
 ]}>
 
 <TabItem value="Table Insert (MySQL)">
@@ -132,6 +133,27 @@ output:
         this.user.name,
         metadata("kafka_topic"),
       ]
+```
+
+</TabItem>
+<TabItem value="Table Insert (DuckDB)">
+
+Write events to a local DuckDB file, creating the table on first run via `init_statement`.
+
+```yaml
+output:
+  sql_insert:
+    driver: duckdb
+    dsn: /tmp/duckburg.duckdb
+    table: vault_deposits
+    columns: [id, duck, gold_coins]
+    args_mapping: "root = [this.id, this.duck, this.gold_coins]"
+    init_statement: |
+      CREATE TABLE IF NOT EXISTS vault_deposits (
+        id         INTEGER PRIMARY KEY,
+        duck       VARCHAR,
+        gold_coins BIGINT
+      )
 ```
 
 </TabItem>
@@ -167,7 +189,7 @@ The following is a list of supported drivers, their placeholder style, and their
 | `spanner` | `projects/[project]/instances/[instance]/databases/dbname` |
 | `trino` | [`http[s]://user[:pass]@host[:port][?parameters]`](https://github.com/trinodb/trino-go-client#dsn-data-source-name) |
 | `gocosmos` | [`AccountEndpoint=<cosmosdb-endpoint>;AccountKey=<cosmosdb-account-key>[;TimeoutMs=<timeout-in-ms>][;Version=<cosmosdb-api-version>][;DefaultDb/Db=<db-name>][;AutoId=<true/false>][;InsecureSkipVerify=<true/false>]`](https://pkg.go.dev/github.com/microsoft/gocosmos#readme-example-usage) |
-| `duckdb` | `/path/to/filename.duckdb[?config_option=value&...]` |
+| `duckdb` | `/path/to/filename.duckdb[?config_option=value&...]` or `:memory:` for ephemeral in-process storage. |
 
 Please note that the `postgres` driver enforces SSL by default, you can override this with the parameter `sslmode=disable` if required.
 
@@ -192,6 +214,8 @@ dsn: postgres://foouser:foopass@localhost:5432/foodb?sslmode=disable
 dsn: oracle://foouser:foopass@localhost:1521/service_name
 
 dsn: db_file.duckdb?threads=4&access_mode=READ_ONLY
+
+dsn: ':memory:'
 ```
 
 ### `table`

--- a/website/docs/components/outputs/sql_insert.md
+++ b/website/docs/components/outputs/sql_insert.md
@@ -141,6 +141,7 @@ output:
 Write events to a local DuckDB file, creating the table on first run via `init_statement`.
 
 ```yaml
+# BENTO LINT DISABLE
 output:
   sql_insert:
     driver: duckdb

--- a/website/docs/components/outputs/sql_raw.md
+++ b/website/docs/components/outputs/sql_raw.md
@@ -163,7 +163,7 @@ The following is a list of supported drivers, their placeholder style, and their
 | `spanner` | `projects/[project]/instances/[instance]/databases/dbname` |
 | `trino` | [`http[s]://user[:pass]@host[:port][?parameters]`](https://github.com/trinodb/trino-go-client#dsn-data-source-name) |
 | `gocosmos` | [`AccountEndpoint=<cosmosdb-endpoint>;AccountKey=<cosmosdb-account-key>[;TimeoutMs=<timeout-in-ms>][;Version=<cosmosdb-api-version>][;DefaultDb/Db=<db-name>][;AutoId=<true/false>][;InsecureSkipVerify=<true/false>]`](https://pkg.go.dev/github.com/microsoft/gocosmos#readme-example-usage) |
-| `duckdb` | `/path/to/filename.duckdb[?config_option=value&...]` |
+| `duckdb` | `/path/to/filename.duckdb[?config_option=value&...]` or `:memory:` for ephemeral in-process storage. |
 
 Please note that the `postgres` driver enforces SSL by default, you can override this with the parameter `sslmode=disable` if required.
 
@@ -188,6 +188,8 @@ dsn: postgres://foouser:foopass@localhost:5432/foodb?sslmode=disable
 dsn: oracle://foouser:foopass@localhost:1521/service_name
 
 dsn: db_file.duckdb?threads=4&access_mode=READ_ONLY
+
+dsn: ':memory:'
 ```
 
 ### `query`

--- a/website/docs/components/processors/sql_insert.md
+++ b/website/docs/components/processors/sql_insert.md
@@ -153,7 +153,7 @@ The following is a list of supported drivers, their placeholder style, and their
 | `spanner` | `projects/[project]/instances/[instance]/databases/dbname` |
 | `trino` | [`http[s]://user[:pass]@host[:port][?parameters]`](https://github.com/trinodb/trino-go-client#dsn-data-source-name) |
 | `gocosmos` | [`AccountEndpoint=<cosmosdb-endpoint>;AccountKey=<cosmosdb-account-key>[;TimeoutMs=<timeout-in-ms>][;Version=<cosmosdb-api-version>][;DefaultDb/Db=<db-name>][;AutoId=<true/false>][;InsecureSkipVerify=<true/false>]`](https://pkg.go.dev/github.com/microsoft/gocosmos#readme-example-usage) |
-| `duckdb` | `/path/to/filename.duckdb[?config_option=value&...]` |
+| `duckdb` | `/path/to/filename.duckdb[?config_option=value&...]` or `:memory:` for ephemeral in-process storage. |
 
 Please note that the `postgres` driver enforces SSL by default, you can override this with the parameter `sslmode=disable` if required.
 
@@ -178,6 +178,8 @@ dsn: postgres://foouser:foopass@localhost:5432/foodb?sslmode=disable
 dsn: oracle://foouser:foopass@localhost:1521/service_name
 
 dsn: db_file.duckdb?threads=4&access_mode=READ_ONLY
+
+dsn: ':memory:'
 ```
 
 ### `table`

--- a/website/docs/components/processors/sql_raw.md
+++ b/website/docs/components/processors/sql_raw.md
@@ -97,6 +97,8 @@ If the query fails to execute then the message will remain unchanged and the err
 <Tabs defaultValue="Table Insert (MySQL)" values={[
 { label: 'Table Insert (MySQL)', value: 'Table Insert (MySQL)', },
 { label: 'Table Query (PostgreSQL)', value: 'Table Query (PostgreSQL)', },
+{ label: 'Enrichment Lookup (DuckDB)', value: 'Enrichment Lookup (DuckDB)', },
+{ label: 'In-Memory Computation (DuckDB)', value: 'In-Memory Computation (DuckDB)', },
 ]}>
 
 <TabItem value="Table Insert (MySQL)">
@@ -133,6 +135,46 @@ pipeline:
 ```
 
 </TabItem>
+<TabItem value="Enrichment Lookup (DuckDB)">
+
+Enrich each message with a field from a DuckDB lookup table. The table is seeded once via `init_statement` and queried per message.
+
+```yaml
+pipeline:
+  processors:
+    - branch:
+        processors:
+          - sql_raw:
+              driver: duckdb
+              dsn: /tmp/duckburg.duckdb
+              query: "SELECT occupation FROM duckburg WHERE name = ?"
+              args_mapping: "root = [this.name]"
+              init_statement: |
+                CREATE TABLE IF NOT EXISTS duckburg (name VARCHAR PRIMARY KEY, occupation VARCHAR);
+                INSERT OR IGNORE INTO duckburg VALUES
+                  ('Scrooge McDuck','Billionaire'),('Donald Duck','Sailor'),
+                  ('Huey Duck','Junior Woodchuck'),('Launchpad McQuack','Pilot');
+              conn_max_open: 1
+        result_map: "root.occupation = this.index(0).occupation"
+```
+
+</TabItem>
+<TabItem value="In-Memory Computation (DuckDB)">
+
+Run SQL expressions against message fields using a DuckDB `:memory:` database(no external file required).
+
+```yaml
+pipeline:
+  processors:
+    - sql_raw:
+        driver: duckdb
+        dsn: ":memory:"
+        query: "SELECT ? * 2 + 1 AS result"
+        args_mapping: "root = [this.random]"
+        conn_max_open: 1
+```
+
+</TabItem>
 </Tabs>
 
 ## Fields
@@ -165,7 +207,7 @@ The following is a list of supported drivers, their placeholder style, and their
 | `spanner` | `projects/[project]/instances/[instance]/databases/dbname` |
 | `trino` | [`http[s]://user[:pass]@host[:port][?parameters]`](https://github.com/trinodb/trino-go-client#dsn-data-source-name) |
 | `gocosmos` | [`AccountEndpoint=<cosmosdb-endpoint>;AccountKey=<cosmosdb-account-key>[;TimeoutMs=<timeout-in-ms>][;Version=<cosmosdb-api-version>][;DefaultDb/Db=<db-name>][;AutoId=<true/false>][;InsecureSkipVerify=<true/false>]`](https://pkg.go.dev/github.com/microsoft/gocosmos#readme-example-usage) |
-| `duckdb` | `/path/to/filename.duckdb[?config_option=value&...]` |
+| `duckdb` | `/path/to/filename.duckdb[?config_option=value&...]` or `:memory:` for ephemeral in-process storage. |
 
 Please note that the `postgres` driver enforces SSL by default, you can override this with the parameter `sslmode=disable` if required.
 
@@ -190,6 +232,8 @@ dsn: postgres://foouser:foopass@localhost:5432/foodb?sslmode=disable
 dsn: oracle://foouser:foopass@localhost:1521/service_name
 
 dsn: db_file.duckdb?threads=4&access_mode=READ_ONLY
+
+dsn: ':memory:'
 ```
 
 ### `query`

--- a/website/docs/components/processors/sql_raw.md
+++ b/website/docs/components/processors/sql_raw.md
@@ -165,6 +165,7 @@ pipeline:
 Run SQL expressions against message fields using a DuckDB `:memory:` database(no external file required).
 
 ```yaml
+# BENTO LINT DISABLE
 pipeline:
   processors:
     - sql_raw:

--- a/website/docs/components/processors/sql_raw.md
+++ b/website/docs/components/processors/sql_raw.md
@@ -140,6 +140,7 @@ pipeline:
 Enrich each message with a field from a DuckDB lookup table. The table is seeded once via `init_statement` and queried per message.
 
 ```yaml
+# BENTO LINT DISABLE
 pipeline:
   processors:
     - branch:

--- a/website/docs/components/processors/sql_select.md
+++ b/website/docs/components/processors/sql_select.md
@@ -157,7 +157,7 @@ The following is a list of supported drivers, their placeholder style, and their
 | `spanner` | `projects/[project]/instances/[instance]/databases/dbname` |
 | `trino` | [`http[s]://user[:pass]@host[:port][?parameters]`](https://github.com/trinodb/trino-go-client#dsn-data-source-name) |
 | `gocosmos` | [`AccountEndpoint=<cosmosdb-endpoint>;AccountKey=<cosmosdb-account-key>[;TimeoutMs=<timeout-in-ms>][;Version=<cosmosdb-api-version>][;DefaultDb/Db=<db-name>][;AutoId=<true/false>][;InsecureSkipVerify=<true/false>]`](https://pkg.go.dev/github.com/microsoft/gocosmos#readme-example-usage) |
-| `duckdb` | `/path/to/filename.duckdb[?config_option=value&...]` |
+| `duckdb` | `/path/to/filename.duckdb[?config_option=value&...]` or `:memory:` for ephemeral in-process storage. |
 
 Please note that the `postgres` driver enforces SSL by default, you can override this with the parameter `sslmode=disable` if required.
 
@@ -182,6 +182,8 @@ dsn: postgres://foouser:foopass@localhost:5432/foodb?sslmode=disable
 dsn: oracle://foouser:foopass@localhost:1521/service_name
 
 dsn: db_file.duckdb?threads=4&access_mode=READ_ONLY
+
+dsn: ':memory:'
 ```
 
 ### `table`


### PR DESCRIPTION
Add DuckDB examples to `sql_insert` (output), `sql_raw` (input/processor) docs and update the DuckDB DSN table row to include `:memory:` for ephemeral in-process storage.